### PR TITLE
Correct variable typo for appDisplayName

### DIFF
--- a/docs/lib/preview-functions.ts
+++ b/docs/lib/preview-functions.ts
@@ -231,7 +231,7 @@ compose.resources{
 val workDir = file("deb-temp")
 val packageName = "${options.packageName.toLowerCase().replace(/[\s.]+/g, "")}"
 val desktopRelativePath = "opt/$packageName/lib/$packageName-$packageName.desktop"
-val appDislayName = "${options.appName}"
+val appDisplayName = "${options.appName}"
 val mainClass = "${options.appName.replace(/\s+/g, "")}"
 val maintainer = "${
     options.linuxMaintainer || "Your Name <youremail@gmail.com>"


### PR DESCRIPTION
The issue #1 is caused by a typo from `appDisplayName`.