### PR TITLE
Replace deprecated exec method with injected task execution approach

### DIFF
--- a/docs/lib/preview-functions.ts
+++ b/docs/lib/preview-functions.ts
@@ -254,6 +254,10 @@ fun promptUserChoice(): String {
     return Scanner(System.\`in\`).nextLine().trim().ifEmpty { "1" }
 }
 
+interface InjectedExecOps {
+    @get:Inject val execOps: ExecOperations
+}
+
 tasks.register("addStartupWMClassToDebDynamic") {
     group = "release"
     description = "Finds .deb file, modifies .desktop, control files, and DEBIAN scripts, and rebuilds it"
@@ -275,8 +279,10 @@ tasks.register("addStartupWMClassToDebDynamic") {
         if (workDir.exists()) workDir.deleteRecursively()
         workDir.mkdirs()
 
+        val injected = project.objects.newInstance<InjectedExecOps>()
+
         // Step 1: Extracting generated debian package
-        exec {
+        injected.execOps.exec {
             commandLine("dpkg-deb", "-R", originalDeb.absolutePath, workDir.absolutePath)
         }
 
@@ -467,10 +473,10 @@ exit 0"""
         println("✅ Updated prerm script to remove terminal symlink")
 
         // Make sure scripts are executable
-        exec {
+        injected.execOps.exec {
             commandLine("chmod", "+x", postinstFile.absolutePath)
         }
-        exec {
+        injected.execOps.exec {
             commandLine("chmod", "+x", prermFile.absolutePath)
         }
 
@@ -485,7 +491,7 @@ exit 0"""
         println("--------------------------------\\n")
 
         // Step 6: Repackaging the debian package back
-        exec {
+        injected.execOps.exec {
             commandLine("dpkg-deb", "-b", workDir.absolutePath, modifiedDeb.absolutePath)
         }
 
@@ -509,7 +515,8 @@ tasks.register("packageDebWithWMClass") {
         println("▶️ Running: \${packagingTask}")
         gradle.includedBuilds.forEach { it.task(":\${packagingTask}") } // just in case of composite builds
 
-        exec {
+        val injected = project.objects.newInstance<InjectedExecOps>()
+        injected.execOps.exec {
             commandLine("./gradlew clean")
             commandLine("./gradlew", packagingTask)
         }


### PR DESCRIPTION
The `exec` method we used will be removed in Gradle 9.0. I specifically got this warning:

```
'exec(Action<ExecSpec>): ExecResult' is deprecated. This method will be removed in Gradle 9.0. Use ExecOperations.exec(Action) or ProviderFactory.exec(Action) instead.
```

Updating the usage of this method is important if the compose desktop app wants to use Gradle 9.0.

According to https://docs.gradle.org/current/userguide/service_injection.html#execoperations, I find that there are two solutions to replace. I chose the latter solution because it looks simpler (may want to replace later if the former is better).

This pull request successfully fixed the warning.